### PR TITLE
Feature/sc 9609 upgrade to prefect 1 0 0

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ runs:
           python3-dev \
           python3-setuptools
 
-        sudo python3 -m pip install prefect==1.2.2
+        sudo python3 -m pip install prefect==1.2.4
 
         prefect backend cloud
         prefect auth login --key ${{ inputs.prefect-api-key }}

--- a/action.yml
+++ b/action.yml
@@ -1,8 +1,8 @@
 name: "prefect"
 description: "A suite of common tools for prefect"
 inputs:
-  prefect-api-token:
-    description: "API token for Prefect Cloud authentication"
+  prefect-api-key:
+    description: "API key for Prefect Cloud authentication"
     required: true
 runs:
   using: "composite"
@@ -16,9 +16,9 @@ runs:
           python3-dev \
           python3-setuptools
 
-        sudo python3 -m pip install prefect==0.15.3
+        sudo python3 -m pip install prefect==1.2.2
 
         prefect backend cloud
-        prefect auth login -t ${{ inputs.prefect-api-token }}
+        prefect auth login --key ${{ inputs.prefect-api-key }}
 
       shell: bash


### PR DESCRIPTION
## What
Update authentication method and upgrade prefect to version 1.2.4

## Why 
https://app.shortcut.com/landinsight/story/9609/upgrade-to-prefect-1-0-0-timebox-5-days

As we use tag in Github workflows, e.g. `landtechnologies/prefect@v1.0.1` this PR doesn't break anything